### PR TITLE
パラメータ更新関数の呼び出しを追加

### DIFF
--- a/src/components/Excute.astro
+++ b/src/components/Excute.astro
@@ -111,5 +111,6 @@
         countInput.value = params.count || "10";
         rankInput.value = params.rank || "5";
         filtervalue.value = params.filter || "under";
+        updateParam();
     }
 </script>


### PR DESCRIPTION
This pull request includes a small change to the `src/components/Excute.astro` file. The change adds a call to the `updateParam` function after setting default values for `countInput`, `rankInput`, and `filtervalue`.

* [`src/components/Excute.astro`](diffhunk://#diff-78f99a07623e056c3390d122d5f2544ba8644726736e9c57f8772688b7d37de5R114): Added a call to `updateParam` to ensure parameters are updated after setting default values.